### PR TITLE
Added queue to default sidekiq labels

### DIFF
--- a/lib/prometheus_exporter/instrumentation/sidekiq.rb
+++ b/lib/prometheus_exporter/instrumentation/sidekiq.rb
@@ -37,6 +37,7 @@ module PrometheusExporter::Instrumentation
       @client.send_json(
         type: "sidekiq",
         name: class_name,
+        queue: queue,
         success: success,
         shutdown: shutdown,
         duration: duration

--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -17,7 +17,7 @@ module PrometheusExporter::Server
     end
 
     def collect(obj)
-      default_labels = { job_name: obj['name'] }
+      default_labels = { job_name: obj['name'], queue: obj['queue'] }
       custom_labels = obj['custom_labels']
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 


### PR DESCRIPTION
Tested this locally:

\# HELP ruby_sidekiq_job_duration_seconds Total time spent in sidekiq jobs.
\# TYPE ruby_sidekiq_job_duration_seconds counter
ruby_sidekiq_job_duration_seconds{job_name="Sidekiq::Extensions::DelayedClass",queue="default"} 0.4530350000713952
ruby_sidekiq_job_duration_seconds{job_name="CreateEventWorker",queue="default"} 1.2993940000305884
ruby_sidekiq_job_duration_seconds{job_name="Sidekiq::Extensions::DelayedModel",queue="default"} 0.0512580000795424

\# HELP ruby_sidekiq_jobs_total Total number of sidekiq jobs executed.
\# TYPE ruby_sidekiq_jobs_total counter
ruby_sidekiq_jobs_total{job_name="Sidekiq::Extensions::DelayedClass",queue="default"} 13
ruby_sidekiq_jobs_total{job_name="CreateEventWorker",queue="default"} 7
ruby_sidekiq_jobs_total{job_name="Sidekiq::Extensions::DelayedModel",queue="default"} 4